### PR TITLE
add storage options for the study

### DIFF
--- a/xgboost-optuna-model-training.ipynb
+++ b/xgboost-optuna-model-training.ipynb
@@ -78,8 +78,7 @@
     "print(\"dask:\", dask.__version__)\n",
     "print(\"dask.distributed:\", dask.distributed.__version__)\n",
     "print(\"optuna:\", optuna.__version__)\n",
-    "print(\"xgboost:\", xgb.__version__)\n",
-    "print(\"coiled:\", coiled.__version__)"
+    "print(\"xgboost:\", xgb.__version__)"
    ]
   },
   {
@@ -265,7 +264,11 @@
    "source": [
     "# create a single study\n",
     "\n",
-    "study = optuna.create_study(study_name=\"nyc-taxi-study\")\n",
+    "study = optuna.create_study(\n",
+    "    study_name=\"nyc-taxi-study\",\n",
+    "    storage=f\"sqlite:///nyc-taxi-study.db\",\n",
+    "    load_if_exists=True,\n",
+    ") \n",
     "\n",
     "executor = ThreadPoolExecutor(4)\n",
     "\n",


### PR DESCRIPTION
In the end, the simplest solution worked best. The trick was to forget about `joblib`